### PR TITLE
Add handling for first model run and type of materialisation. Update …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A sophisticated exploration of dbt macro capabilities, pushing the boundaries of
 
 ## Why This Project Exists
 
-As a passionate dbt practitioner, I noticed a gap in the ecosystem for sophisticated warehouse management solutions. This project was born from the desire to:
+As a passionate dbt practitioner, I noticed a gap in the ecosystem for sophisticated solutions. This project was born from the desire to:
 
 - Explore the full potential of dbt macros
 - Experiment with novel solutions
@@ -16,7 +16,7 @@ As a passionate dbt practitioner, I noticed a gap in the ecosystem for sophistic
    ```yaml
    packages:
      - git: "https://github.com/DominikGolebiewski/dbt-macro-polo.git"
-       revision: 0.0.1  # Specify the git release version you want to use
+       revision: 0.0.2  # Specify the git release version you want to use
    ```
 
 2. **Install the package**
@@ -28,6 +28,7 @@ As a passionate dbt practitioner, I noticed a gap in the ecosystem for sophistic
 
 ### [get_warehouse](macros/get_warehouse/get_warehouse.sql)
 
+** Snowflake Only **
 Dynamically sets warehouse size based on operation context (incremental and full-refresh). Perfect for optimising compute costs.
 
 #### Configuration Requirements
@@ -57,9 +58,9 @@ Check out the [integration tests](integration_tests/dbt_project.yml) for example
 
 ```sql
 {{ config(
-        snowflake_warehouse=dbt_macro_polo.get_warehouse(
-        incremental_size='s', {# Size for incremental runs #}
-        full_refresh_size='xl' {# Size for full-refresh runs (optional) #}
+        pre_hook=[
+            'use warehouse {{ dbt_macro_polo.get_warehouse(incremental_size="s", full_refresh_size="xl") }}'
+        ]
     )
 ) }}
 ```
@@ -79,6 +80,15 @@ dbt run --select my_model --full-refresh
 ```
 
 3. **Resolution Examples**
+
+For initial run:
+
+```sql
+-- Development environment (target: dev)
+use warehouse development_warehouse_xl;
+-- Production environment (target: prod)
+use warehouse production_warehouse_xl;
+```
 
 For incremental runs:
 
@@ -101,6 +111,10 @@ use warehouse production_warehouse_xl;
 The warehouse name is dynamically constructed using:
 - Environment prefix (from `warehouse_config`)
 - Warehouse size (based on run type)
+
+If full refresh size is not provided, the warehouse size will be the same as the incremental size.
+View materialisation will always use the incremental size even if full refresh size is provided.
+Any other materialisation type other then `view`, `table` or `incremental` will use the target warehouse size.
 
 ## Contributing 🤝
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ As a passionate dbt practitioner, I noticed a gap in the ecosystem for sophistic
 - Experiment with novel solutions
 - Share novel solutions with the dbt community
 
+
+**Important**
+Ensure you thoroughly test these macros in your environment prior to using them in production. These are largely experimental features intended as a starting point or interim solution, requiring further assessment and comprehensive testing.
+
 ## Enable in Your Project 🔌
 
 1. **Add to packages.yml**

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -38,6 +38,9 @@ vars:
       integration_tests_ci_b:
         target_name: ci_b
         warehouse_name_prefix: ci_b
+      developer:
+        target_name: dev
+        warehouse_name_prefix: developer
 
 
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -38,9 +38,7 @@ vars:
       integration_tests_ci_b:
         target_name: ci_b
         warehouse_name_prefix: ci_b
-      developer:
-        target_name: dev
-        warehouse_name_prefix: developer
+
 
 
 

--- a/integration_tests/models/test_get_warehouse/property/test_get_warehouse_full_refresh.yaml
+++ b/integration_tests/models/test_get_warehouse/property/test_get_warehouse_full_refresh.yaml
@@ -4,7 +4,7 @@ models:
 - name: test_get_warehouse_full_refresh
   description: "Tests the get_warehouse macro functionality for full refresh scenarios"
   config:
-    materialized: view
+    materialized: table
     tags: [ 'full_refresh' ]
   columns:
   - name: warehouse_size_incremental_and_full_refresh_fallback

--- a/integration_tests/models/test_get_warehouse/property/test_get_warehouse_in_pre_hook.yaml
+++ b/integration_tests/models/test_get_warehouse/property/test_get_warehouse_in_pre_hook.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+models:
+- name: test_get_warehouse_in_pre_hook
+  description: Tests the get_warehouse macro's behaviour when materialisation is set in pre-hook. Ensures warehouse names are correctly resolved for table materialisation, including fallback scenarios and size variations.
+  config:
+    materialized: incremental
+    incremental_strategy: 'delete+insert'
+    unique_key: record_a
+    tags: [ 'full_refresh' ]
+    pre_hook: 'use warehouse {{ dbt_macro_polo.get_warehouse("xs", "m") }}'
+    enabled: false
+ 

--- a/integration_tests/models/test_get_warehouse/property/test_get_warehouse_incremental.yaml
+++ b/integration_tests/models/test_get_warehouse/property/test_get_warehouse_incremental.yaml
@@ -4,8 +4,10 @@ models:
 - name: test_get_warehouse_incremental
   description: "Tests the get_warehouse macro functionality for incremental models"
   config:
-    materialized: view
-    tags: [ 'incremental' ]
+    materialized: incremental
+    incremental_strategy: 'delete+insert'
+    unique_key: id
+    tags: [ 'incremental', 'full_refresh' ]
   columns:
   - name: warehouse_size_incremental_and_full_refresh_fallback
     description: "Tests get_warehouse with only incremental size provided"
@@ -19,11 +21,11 @@ models:
     tests:
     - not_null
     - accepted_values:
-        values: [ 'ci_a_s' ]
+        values: [ 'ci_a_s', 'ci_a_l' ]
 
   - name: warehouse_size_full_refresh
     description: "Tests get_warehouse with different sizes for incremental vs full refresh"
     tests:
     - not_null
     - accepted_values:
-        values: [ 'ci_a_m' ]
+        values: [ 'ci_a_m', 'ci_a_xl' ]

--- a/integration_tests/models/test_get_warehouse/test_get_warehouse_full_refresh.sql
+++ b/integration_tests/models/test_get_warehouse/test_get_warehouse_full_refresh.sql
@@ -1,6 +1,6 @@
 {% set warehouse_size_incremental_and_full_refresh_fallback = dbt_macro_polo.get_warehouse('xs') %}
 {% set warehouse_size_incremental_and_full_refresh = dbt_macro_polo.get_warehouse('s', 'l') %}
-{% set warehouse_size_full_refresh = dbt_macro_polo.get_warehouse('s', 'xl') %}
+{% set warehouse_size_full_refresh = dbt_macro_polo.get_warehouse('m', 'xl') %}
 
 select 
     '{{ warehouse_size_incremental_and_full_refresh_fallback }}' as warehouse_size_incremental_and_full_refresh_fallback,

--- a/integration_tests/models/test_get_warehouse/test_get_warehouse_in_pre_hook.sql
+++ b/integration_tests/models/test_get_warehouse/test_get_warehouse_in_pre_hook.sql
@@ -1,0 +1,3 @@
+select 
+    'a' as record_a,
+    'b' as record_b

--- a/integration_tests/models/test_get_warehouse/test_get_warehouse_incremental.sql
+++ b/integration_tests/models/test_get_warehouse/test_get_warehouse_incremental.sql
@@ -3,6 +3,8 @@
 {% set warehouse_size_full_refresh = dbt_macro_polo.get_warehouse('m', 'xl') %}
 
 select 
+    md5(current_timestamp()) as id,
     '{{ warehouse_size_incremental_and_full_refresh_fallback }}' as warehouse_size_incremental_and_full_refresh_fallback,
     '{{ warehouse_size_incremental_and_full_refresh }}' as warehouse_size_incremental_and_full_refresh,
-    '{{ warehouse_size_full_refresh }}' as warehouse_size_full_refresh
+    '{{ warehouse_size_full_refresh }}' as warehouse_size_full_refresh,
+    current_timestamp() as loaded_at

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -1,25 +1,44 @@
-# Base config that other profiles inherit from
-config:
-  snowflake_base: &snowflake_base
-    type: snowflake
-    account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
-    user: "{{ env_var('DBT_SNOWFLAKE_USERNAME') }}"
-    password: "{{ env_var('DBT_SNOWFLAKE_PW') }}"
-    warehouse: "{{ env_var('DBT_SNOWFLAKE_WAREHOUSE') }}"
-    database: "{{ env_var('DBT_SNOWFLAKE_DATABASE') }}"
-    role: "{{ env_var('DBT_SNOWFLAKE_ROLE') }}"
-    threads: 10
-    client_session_keep_alive: False
-    query_tag: "dbt_macro_polo_integration_tests"
-    authenticator: username_password_mfa
-
 integration_tests:
   target: ci_a
   outputs:
     ci_a:
-      <<: *snowflake_base
+      type: snowflake
+      account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
+      user: "{{ env_var('DBT_SNOWFLAKE_USERNAME') }}"
+      password: "{{ env_var('DBT_SNOWFLAKE_PW') }}"
+      warehouse: "{{ env_var('DBT_SNOWFLAKE_WAREHOUSE') }}"
+      database: "{{ env_var('DBT_SNOWFLAKE_DATABASE') }}"
+      role: "{{ env_var('DBT_SNOWFLAKE_ROLE') }}"
+      threads: 10
+      client_session_keep_alive: False
+      query_tag: "dbt_macro_polo_integration_tests"
+      authenticator: username_password_mfa
       schema: "{{ env_var('DBT_SNOWFLAKE_SCHEMA') }}_ci_a"
     
     ci_b:
-      <<: *snowflake_base
+      type: snowflake
+      account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
+      user: "{{ env_var('DBT_SNOWFLAKE_USERNAME') }}"
+      password: "{{ env_var('DBT_SNOWFLAKE_PW') }}"
+      warehouse: "{{ env_var('DBT_SNOWFLAKE_WAREHOUSE') }}"
+      database: "{{ env_var('DBT_SNOWFLAKE_DATABASE') }}"
+      role: "{{ env_var('DBT_SNOWFLAKE_ROLE') }}"
+      threads: 10
+      client_session_keep_alive: False
+      query_tag: "dbt_macro_polo_integration_tests"
+      authenticator: username_password_mfa
       schema: "{{ env_var('DBT_SNOWFLAKE_SCHEMA') }}_ci_b"
+
+    dev:
+      type: snowflake
+      account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
+      user: "{{ env_var('DBT_SNOWFLAKE_USERNAME') }}"
+      password: "{{ env_var('DBT_SNOWFLAKE_PW') }}"
+      warehouse: "{{ env_var('DBT_SNOWFLAKE_WAREHOUSE') }}"
+      database: "{{ env_var('DBT_SNOWFLAKE_DATABASE') }}"
+      role: "{{ env_var('DBT_SNOWFLAKE_ROLE') }}"
+      threads: 10
+      client_session_keep_alive: False
+      query_tag: "dbt_macro_polo_integration_tests"
+      authenticator: username_password_mfa
+      schema: "{{ env_var('DBT_SNOWFLAKE_SCHEMA') }}"

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -31,13 +31,13 @@ fi
 echo -e "${BLUE}Installing dbt dependencies...${NC}"
 poetry run dbt deps
 
-# Run incremental tests
-echo -e "${BLUE}Running incremental tests...${NC}"
-poetry run dbt build --select tag:incremental --fail-fast
-
 # Run full refresh tests
 echo -e "${BLUE}Running full refresh tests...${NC}"
 poetry run dbt build --select tag:full_refresh --full-refresh --fail-fast
+
+# Run incremental tests
+echo -e "${BLUE}Running incremental tests...${NC}"
+poetry run dbt build --select tag:incremental --fail-fast
 
 # Run target ci_b tests
 echo -e "${BLUE}Running target prod_etl tests...${NC}"

--- a/macros/get_warehouse/get_default_warehouse_sizes.sql
+++ b/macros/get_warehouse/get_default_warehouse_sizes.sql
@@ -8,9 +8,13 @@
 
 {# Constants - Macro Polo knows the standard warehouse sizes #}
 {% macro snowflake__get_default_warehouse_sizes() %}
-    {# Macro Polo suggests warehouse sizes from his travels #}
+    {# Macro Polo suggests warehouse sizes from project configuration #}
     {% set macro_name = 'MACRO_POLO_GET_DEFAULT_WAREHOUSE_SIZES' %}
-    {% set sizes = ['xs', 's', 'm', 'l', 'xl', '2xl'] %}
+    
+    {# Get sizes from warehouse_config, fallback to default if not specified #}
+    {% set config = var('warehouse_config', {}) %}
+    {% set sizes = config.get('warehouse_size', ['xs', 's', 'm', 'l', 'xl', '2xl']) %}
+    
     {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo suggests these warehouse sizes", sizes) }}
     {{ return(sizes) }}
 {% endmacro %}

--- a/macros/get_warehouse/get_warehouse.sql
+++ b/macros/get_warehouse/get_warehouse.sql
@@ -31,17 +31,12 @@
 
     {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has retrieved the materialization type", materialization) }}
 
-    {# For views and ephemeral, use incremental size as they dont store data #}
-    {% if materialization in ['view', 'ephemeral'] %}
-        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to use the incremental size for views and ephemeral", sizes.incremental) }}
-        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to check if full refresh or first run", {
-            'flags.FULL_REFRESH': flags.FULL_REFRESH,
-            'adapter.get_relation(this.database, this.schema, this.table)': adapter.get_relation(this.database, this.schema, this.table)
-        }) }}
+    {# For views, use incremental size as they dont store data #}
+    {% if materialization == 'view' %}
+        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to use the incremental size for views", sizes.incremental) }}
         {% set size = sizes.incremental %}
     {# For tables and incremental models, check if full refresh or first run #}
     {% elif (flags.FULL_REFRESH or not adapter.get_relation(this.database, this.schema, this.table)) %}
-
         {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to use the full refresh size for tables and incremental models", sizes.fullrefresh) }}
         {% set size = sizes.fullrefresh %}
     {% elif materialization in ['table', 'incremental'] %}

--- a/macros/get_warehouse/get_warehouse.sql
+++ b/macros/get_warehouse/get_warehouse.sql
@@ -9,7 +9,7 @@
 {# Main Warehouse Selection Macro #}
 {% macro snowflake__get_warehouse(incremental_size, fullrefresh_size=none) %}
     {# Macro Polo coordinates the warehouse selection journey #}
-    {% set macro_name = 'POLO_GETS_WAREHOUSE' %}
+    {% set macro_name = 'MACRO_POLO_GET_WAREHOUSE' %}
     {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo begins his warehouse exploration", {
         'incremental_size': incremental_size,
         'fullrefresh_size': fullrefresh_size,
@@ -23,12 +23,33 @@
     
     {# Validate input parameters #}
     {% set sizes = dbt_macro_polo.validate_input_parameters(incremental_size, fullrefresh_size) %}
+
+    {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has validated the input parameters", sizes) }}
     
-    {# Select appropriate size based on run type #}
-    {% if flags.FULL_REFRESH and sizes.fullrefresh is not none %}
-        {% set size = sizes.fullrefresh %}
-    {% else %}
+    {# Get materialization type #}
+    {% set materialization = model.config.get('materialized') %}
+
+    {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has retrieved the materialization type", materialization) }}
+
+    {# For views and ephemeral, use incremental size as they dont store data #}
+    {% if materialization in ['view', 'ephemeral'] %}
+        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to use the incremental size for views and ephemeral", sizes.incremental) }}
+        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to check if full refresh or first run", {
+            'flags.FULL_REFRESH': flags.FULL_REFRESH,
+            'adapter.get_relation(this.database, this.schema, this.table)': adapter.get_relation(this.database, this.schema, this.table)
+        }) }}
         {% set size = sizes.incremental %}
+    {# For tables and incremental models, check if full refresh or first run #}
+    {% elif (flags.FULL_REFRESH or not adapter.get_relation(this.database, this.schema, this.table)) %}
+
+        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to use the full refresh size for tables and incremental models", sizes.fullrefresh) }}
+        {% set size = sizes.fullrefresh %}
+    {% elif materialization in ['table', 'incremental'] %}
+        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to use the incremental size for tables and incremental models", sizes.incremental) }}
+        {% set size = sizes.incremental %}
+    {% else %}
+        {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo has determined to use the target warehouse size", target.warehouse) }}
+        {% set size = target.warehouse %}
     {% endif %}
     
     {% set validated_size = dbt_macro_polo.validate_warehouse_size(size, available_sizes) %}

--- a/macros/get_warehouse/validate_input_parameters.sql
+++ b/macros/get_warehouse/validate_input_parameters.sql
@@ -9,7 +9,7 @@
 {# Input Validation - Macro Polo validates the input parameters #}
 {% macro snowflake__validate_input_parameters(incremental_size, fullrefresh_size) %}
     {# Macro Polo checks if the warehouse sizes are provided correctly #}
-    {% set macro_name = 'POLO_VALIDATES_INPUT_PARAMETERS' %}
+    {% set macro_name = 'MACRO_POLO_VALIDATES_INPUT_PARAMETERS' %}
     {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo examines the input parameters", {
         'incremental_size': incremental_size,
         'fullrefresh_size': fullrefresh_size
@@ -23,7 +23,7 @@
     
     {% set result = {
         "incremental": incremental_size | trim | lower,
-        "fullrefresh": fullrefresh_size | trim | lower if fullrefresh_size is not none else none
+        "fullrefresh": fullrefresh_size | trim | lower if fullrefresh_size is not none else incremental_size | trim | lower
     } %}
     
     {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo confirms the parameters are valid", result) }}

--- a/macros/get_warehouse/validate_warehouse_config.sql
+++ b/macros/get_warehouse/validate_warehouse_config.sql
@@ -9,7 +9,7 @@
 {# Config Validation - Macro Polo validates the warehouse configuration #}
 {% macro snowflake__validate_warehouse_config(config) %}
     {# Macro Polo ensures the warehouse configuration is complete #}
-    {% set macro_name = 'POLO_VALIDATES_WAREHOUSE_CONFIG' %}
+    {% set macro_name = 'MACRO_POLO_VALIDATES_WAREHOUSE_CONFIG' %}
     {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo reviews the warehouse configuration", config) }}
 
     {% if not config %}

--- a/macros/get_warehouse/validate_warehouse_size.sql
+++ b/macros/get_warehouse/validate_warehouse_size.sql
@@ -9,7 +9,7 @@
 {# Size Validation - Macro Polo validates the warehouse size #}
 {% macro snowflake__validate_warehouse_size(size, available_sizes) %}
     {# Macro Polo ensures the warehouse size is valid #}
-    {% set macro_name = 'POLO_VALIDATES_WAREHOUSE_SIZE' %}
+    {% set macro_name = 'MACRO_POLO_VALIDATES_WAREHOUSE_SIZE' %}
     {% set normalized_size = size | trim | lower %}
     
     {{ dbt_macro_polo.log_debug(macro_name, "Macro Polo checks the warehouse size", {


### PR DESCRIPTION
Refactor to manage the model's initial run. Include handling for materialisation types and set a default configuration for the target warehouse. Update the documentation to explicitly recommend using this macro in the pre-hook, rather than snowflake_warehouse, due to current behavioural limitations outlined in this issue: https://github.com/dbt-labs/dbt-snowflake/issues/103.