### PR TITLE
Support parameter-driven delete for selective refresh runs

### DIFF
--- a/macros/utility/get_delete_insert_merge_sql.sql
+++ b/macros/utility/get_delete_insert_merge_sql.sql
@@ -8,9 +8,17 @@
 
     {% if unique_key %}
         {{ dbt_macro_polo.handle_warehouse_switch('delete') }}
-        {% if unique_key is sequence and unique_key is not string %}
+        {% if var('selective_refresh', false) == true %}
+            {#--
+                Parameter-driven delete: the WHERE expression is built from CLI
+                vars by the project-provided filter macro, not from a join against
+                source. This makes the delete window equal to the reprocess window
+                even when upstream removed rows that source no longer covers.
+            --#}
             delete from {{ target }}
-            -- TODO: Add a comment to the query to indicate that it is a delete operation
+            where {{ dbt_macro_polo.polo_selective_refresh_filter() }};
+        {% elif unique_key is sequence and unique_key is not string %}
+            delete from {{ target }}
             using {{ source }}
             where (
                 {% for key in unique_key %}

--- a/macros/utility/polo_selective_refresh_filter.sql
+++ b/macros/utility/polo_selective_refresh_filter.sql
@@ -1,0 +1,26 @@
+{#--
+    Extension point for selective_refresh.
+
+    When `--vars '{"selective_refresh": true, ...}'` is passed, the delete branch
+    of `default__get_delete_insert_merge_sql` calls this macro to build the SQL
+    WHERE expression that scopes the delete. Consumers override
+    `default__polo_selective_refresh_filter` in their own project (via the
+    dispatch search_order) to plug in their own filter implementation — e.g.
+    delegating to a filter-builder in another package — without forcing polo to
+    depend on that package.
+
+    The default raises a compile-time error so misconfiguration is loud and early.
+--#}
+
+{% macro polo_selective_refresh_filter() %}
+    {{ return(adapter.dispatch('polo_selective_refresh_filter', 'dbt_macro_polo')()) }}
+{% endmacro %}
+
+{% macro default__polo_selective_refresh_filter() %}
+    {{- exceptions.raise_compiler_error(
+        "selective_refresh=true was passed but no filter macro is configured. "
+        "Define `default__polo_selective_refresh_filter` in your project's macros "
+        "and add `dbt_macro_polo` to your dispatch search_order in dbt_project.yml. "
+        "The macro must return a SQL WHERE expression (without the WHERE keyword)."
+    ) -}}
+{% endmacro %}


### PR DESCRIPTION
# Description

Please iunclude a synopsis of the changes and the underlying issue. Please also include important motivation and context. List any dependencies needed for this modification.

Incremental models that use `get_delete_insert_merge_sql` normally delete target rows by matching keys present in the incremental `source` (either `DELETE … USING source` or `DELETE … WHERE unique_key IN (SELECT … FROM source)`). That behaviour is correct for day-to-day incremental loads, but it is wrong for **selective refresh** runs where the goal is to reprocess a fixed window (dates, retailers, etc.) defined by CLI vars rather than by whatever happens to be in `source` today.

During selective refresh, upstream data may have **removed** rows that no longer appear in `source`. A source-driven delete never touches those rows on the target, so stale data survives even though the model SQL and insert path are scoped to the refresh window. The delete window must match the **reprocess** window, not the set of keys currently visible upstream.

This PR adds:

1. **`polo_selective_refresh_filter`** — a dispatched extension point that returns a SQL predicate (without the `WHERE` keyword). The default implementation raises a compile-time error so `selective_refresh=true` fails loudly if no consumer override is configured.

2. **A new branch in `default__get_delete_insert_merge_sql`** — when `var('selective_refresh', false) == true`, delete from the target using `where {{ dbt_macro_polo.polo_selective_refresh_filter() }}` instead of joining or subquerying against `source`. The insert path is unchanged.

Consumers implement filtering in their own project (for example delegating to an existing filter macro in another package) by defining `default__polo_selective_refresh_filter` and adding `dbt_macro_polo` to `dispatch` `search_order` in `dbt_project.yml`. Polo does not take a hard dependency on any filter-builder package.

**Example invocation** (consumer project):

```bash
dbt run --vars '{"selective_refresh": true, "start_date": "2025-05-01", "end_date": "2025-05-20", "retailer_list": ["morrisons"]}' -m <model>
```

This aligns delete behaviour with the existing `selective_refresh` flag used elsewhere in the package (e.g. warehouse optimiser row-count checks).

Fixes #

## Type of change

Please mark the appropriate change:

- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (non-breaking modification that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to fail to function properly)
- [ ] Maintenance (non-breaking modification that improves the code functionality or performance)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you performed to validate your changes. Please provide instructions so that we can reproduce. Please include any additional information about your test configuration.

- [ ] Test name A
- [ ] Test name B

Validated by reviewing compiled SQL for `get_delete_insert_merge_sql` when `selective_refresh` is true vs false. Consumer projects should override `default__polo_selective_refresh_filter` and run a selective refresh against a model that uses delete+insert incremental strategy, confirming the generated `DELETE` uses the parameter-driven predicate and not a join to `source`.

**Test Configuration**:
* DBT Version: (consumer project)
* DBT Dependencies and version: Requires consumer override of `default__polo_selective_refresh_filter` and `dispatch` configuration; no new package dependencies in polo itself.

# Attachments:


- [ ] I'm including run logs.
- [ ] I'm attaching links to resources supporting my pull request.
- [ ] I'm including screenshots.

Please post any logs (text files, screenshots, or URLs) that support this pull request here.
These might include test cases, commands needed to reproduce the precise behaviour of the code, 
more detailed documentation, or pictures that support this pull request.

Each supplementary attachment should include a brief description of what it represents and what it covers.

# Post-deployment instructions:

After merging, consumer projects that use selective refresh with delete+insert incremental models should:

1. Add a macro `default__polo_selective_refresh_filter` that returns their refresh-window predicate (e.g. call into their existing `selective_refresh_filter` implementation).
2. Ensure `dbt_macro_polo` appears in `dispatch` `search_order` for the `polo_selective_refresh_filter` macro namespace.
3. Run selective refresh with `--vars '{"selective_refresh": true, ...}'` as today; no change to the insert path.

Models that do not pass `selective_refresh=true` are unaffected and keep the existing source-driven delete behaviour.

# Checklist:

- [ ] This code relates to an issue that has been evaluated and approved for development
- [x] My code adheres to the project's style guidelines
- [x] I conducted a self-review of my code
- [x] I've commented my code, especially in difficult-to-understand places
- [ ] I've made the necessary changes to the documentation and the README.md (if applicable)
- [ ] There are no new warnings as a result of my change
- [ ] I've included tests and descriptions to show that my fix is effective or that my feature works
- [ ] Following my changes, both new and existing integration tests pass locally and CI pipeline