### PR TITLE
Gate selective refresh delete behind model meta flag

### DIFF
--- a/macros/utility/get_delete_insert_merge_sql.sql
+++ b/macros/utility/get_delete_insert_merge_sql.sql
@@ -8,12 +8,18 @@
 
     {% if unique_key %}
         {{ dbt_macro_polo.handle_warehouse_switch('delete') }}
-        {% if var('selective_refresh', false) == true %}
+        {% if var('selective_refresh', false) == true
+              and config.get('meta', {}).get('selective_refresh_enabled', false) == true %}
             {#--
                 Parameter-driven delete: the WHERE expression is built from CLI
                 vars by the project-provided filter macro, not from a join against
                 source. This makes the delete window equal to the reprocess window
                 even when upstream removed rows that source no longer covers.
+
+                Gated on `meta.selective_refresh_enabled` so models that havent
+                opted in fall through to the standard sequence-key / in-clause
+                delete — protects against a global --vars selective_refresh=true
+                accidentally wiping rectangles in non-fact tables.
             --#}
             delete from {{ target }}
             where {{ dbt_macro_polo.polo_selective_refresh_filter() }};


### PR DESCRIPTION
# Description

Please iunclude a synopsis of the changes and the underlying issue. Please also include important motivation and context. List any dependencies needed for this modification.

After merging selective refresh support (#12), a global `--vars '{"selective_refresh": true, ...}'` would apply the parameter-driven delete path to every incremental model using `get_delete_insert_merge_sql`, including tables that have not been validated for rectangle deletes. This change requires `meta.selective_refresh_enabled: true` on the model in addition to the `selective_refresh` var, so only opted-in models use `polo_selective_refresh_filter()`; others keep the standard sequence-key or `IN`-clause delete behaviour.

Fixes #

## Type of change

Please mark the appropriate change:

- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (non-breaking modification that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to fail to function properly)
- [ ] Maintenance (non-breaking modification that improves the code functionality or performance)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you performed to validate your changes. Please provide instructions so that we can reproduce. Please include any additional information about your test configuration.

- [ ] Test name A
- [ ] Test name B

**Test Configuration**:
* DBT Version:
* DBT Dependencies and version:

# Attachments:


- [ ] I'm including run logs.
- [ ] I'm attaching links to resources supporting my pull request.
- [ ] I'm including screenshots.

Please post any logs (text files, screenshots, or URLs) that support this pull request here.
These might include test cases, commands needed to reproduce the precise behaviour of the code, 
more detailed documentation, or pictures that support this pull request.

Each supplementary attachment should include a brief description of what it represents and what it covers.

# Post-deployment instructions:

Any instructions for after the release should be placed here. If relevant, these should be detailed commands 
with explanations and comments.

On consuming projects, set `meta.selective_refresh_enabled: true` on each model that should use parameter-driven deletes when running with `selective_refresh: true`. Models without this meta continue to use the existing delete logic.

# Checklist:

- [ ] This code relates to an issue that has been evaluated and approved for development
- [x] My code adheres to the project's style guidelines
- [x] I conducted a self-review of my code
- [x] I've commented my code, especially in difficult-to-understand places
- [ ] I've made the necessary changes to the documentation and the README.md (if applicable)
- [ ] There are no new warnings as a result of my change
- [ ] I've included tests and descriptions to show that my fix is effective or that my feature works
- [ ] Following my changes, both new and existing integration tests pass locally and CI pipeline

Made with [Cursor](https://cursor.com)