### PR TITLE
Selective refresh hooks: polo_is_selective_refresh and keys-aware filter probe

### DIFF
--- a/macros/utility/get_delete_insert_merge_sql.sql
+++ b/macros/utility/get_delete_insert_merge_sql.sql
@@ -8,12 +8,18 @@
 
     {% if unique_key %}
         {{ dbt_macro_polo.handle_warehouse_switch('delete') }}
-        {% if var('selective_refresh', false) == true %}
+        {% if var('selective_refresh', false) == true
+              and config.get('meta', {}).get('selective_refresh_enabled', false) == true %}
             {#--
                 Parameter-driven delete: the WHERE expression is built from CLI
                 vars by the project-provided filter macro, not from a join against
                 source. This makes the delete window equal to the reprocess window
                 even when upstream removed rows that source no longer covers.
+
+                Gated on `meta.selective_refresh_enabled` so models that havent
+                opted in fall through to the standard sequence-key / in-clause
+                delete — protects against a global --vars selective_refresh=true
+                accidentally wiping rectangles in non-fact tables.
             --#}
             delete from {{ target }}
             where {{ dbt_macro_polo.polo_selective_refresh_filter() }};

--- a/macros/utility/get_delete_insert_merge_sql.sql
+++ b/macros/utility/get_delete_insert_merge_sql.sql
@@ -8,8 +8,7 @@
 
     {% if unique_key %}
         {{ dbt_macro_polo.handle_warehouse_switch('delete') }}
-        {% if var('selective_refresh', false) == true
-              and config.get('meta', {}).get('selective_refresh_enabled', false) == true %}
+        {% if dbt_macro_polo.polo_is_selective_refresh() %}
             {#--
                 Parameter-driven delete: the WHERE expression is built from CLI
                 vars by the project-provided filter macro, not from a join against

--- a/macros/utility/polo_is_selective_refresh.sql
+++ b/macros/utility/polo_is_selective_refresh.sql
@@ -1,0 +1,24 @@
+{#--
+    Extension point: "is selective_refresh active for this model on this run?"
+
+    polo's delete+insert strategy (get_delete_insert_merge_sql) and its
+    warehouse-optimiser upstream probe (check_upstream_row_count) both branch on
+    this question. polo does NOT own the selective_refresh feature and must not
+    depend on the package that does, so it asks through this hook. Consumers
+    override `default__polo_is_selective_refresh` (via the dispatch search_order)
+    to delegate to their own implementation — e.g. a feature macro in another
+    package — without forcing polo to depend on it.
+
+    The default returns false: a polo consumer that has not wired up
+    selective_refresh simply gets standard incremental behaviour. Unlike the
+    filter hook, this MUST NOT raise — it is evaluated on every incremental
+    delete and every upstream probe, not only when selective_refresh is requested.
+--#}
+
+{% macro polo_is_selective_refresh() %}
+    {{ return(adapter.dispatch('polo_is_selective_refresh', 'dbt_macro_polo')()) }}
+{% endmacro %}
+
+{% macro default__polo_is_selective_refresh() %}
+    {{ return(false) }}
+{% endmacro %}

--- a/macros/utility/polo_selective_refresh_filter.sql
+++ b/macros/utility/polo_selective_refresh_filter.sql
@@ -9,14 +9,19 @@
     delegating to a filter-builder in another package — without forcing polo to
     depend on that package.
 
+    An optional `keys` argument is passed through to the consumer's implementation.
+    Polo's delete branch calls this with no argument (the consumer decides the
+    default); the upstream row-count probe passes a per-upstream `keys` so each
+    upstream is filtered with the key type it actually stores.
+
     The default raises a compile-time error so misconfiguration is loud and early.
 --#}
 
-{% macro polo_selective_refresh_filter() %}
-    {{ return(adapter.dispatch('polo_selective_refresh_filter', 'dbt_macro_polo')()) }}
+{% macro polo_selective_refresh_filter(keys=none, relation=none) %}
+    {{ return(adapter.dispatch('polo_selective_refresh_filter', 'dbt_macro_polo')(keys, relation)) }}
 {% endmacro %}
 
-{% macro default__polo_selective_refresh_filter() %}
+{% macro default__polo_selective_refresh_filter(keys=none, relation=none) %}
     {{- exceptions.raise_compiler_error(
         "selective_refresh=true was passed but no filter macro is configured. "
         "Define `default__polo_selective_refresh_filter` in your project's macros "

--- a/macros/warehouse_optimiser/check_upstream_row_count.sql
+++ b/macros/warehouse_optimiser/check_upstream_row_count.sql
@@ -102,7 +102,7 @@
             select count(*) as row_count
             from {{ upstream_relation }}
             {% if target_exists and timestamp_column %}
-                {% if var('selective_refresh', false) == false %}
+                {% if not dbt_macro_polo.polo_is_selective_refresh() %}
                     where {{ timestamp_column }} > {{ maximum_timestamp }}
                 {% else %}
                     where {{ dbt_macro_polo.polo_selective_refresh_filter(keys=keys, relation=upstream_name) }}

--- a/macros/warehouse_optimiser/check_upstream_row_count.sql
+++ b/macros/warehouse_optimiser/check_upstream_row_count.sql
@@ -46,8 +46,14 @@
 
         {# Get total row count from upstream models #}
         {%- for dependency in upstream_dependency -%}
-            {%- set rows = dbt_macro_polo.check_upstream_row_count(target_exists, dependency, timestamp_column, warehouse, maximum_timestamp) -%}
-            {{ dbt_macro_polo.logging(message="Row count for " ~ dependency, model_id=model_id, status=rows) }}
+            {#-- Each entry is either a plain name (uses the model's default keys) or a
+                 mapping {name, keys} for per-upstream key resolution — needed when the
+                 upstreams mix business-key (e.g. staging) and surrogate-key (e.g.
+                 intermediary) tables, so each is counted with the keys it actually holds. --#}
+            {%- set dep_name = dependency.get('name') if dependency is mapping else dependency -%}
+            {%- set dep_keys = dependency.get('keys') if dependency is mapping else none -%}
+            {%- set rows = dbt_macro_polo.check_upstream_row_count(target_exists, dep_name, timestamp_column, warehouse, maximum_timestamp, dep_keys) -%}
+            {{ dbt_macro_polo.logging(message="Row count for " ~ dep_name ~ (" [keys=" ~ dep_keys ~ "]" if dep_keys else ""), model_id=model_id, status=rows) }}
             {%- set row_count.value = row_count.value + rows -%}
         {%- endfor -%}
         
@@ -63,11 +69,11 @@
     {{ return(row_count.value) }}
 {%- endmacro -%}
 
-{% macro check_upstream_row_count(target_exists, upstream_relation, timestamp_column, warehouse, maximum_timestamp) %}
-    {{ return(adapter.dispatch('check_upstream_row_count', 'dbt_macro_polo')(target_exists, upstream_relation, timestamp_column, warehouse, maximum_timestamp)) }}
+{% macro check_upstream_row_count(target_exists, upstream_relation, timestamp_column, warehouse, maximum_timestamp, keys=none) %}
+    {{ return(adapter.dispatch('check_upstream_row_count', 'dbt_macro_polo')(target_exists, upstream_relation, timestamp_column, warehouse, maximum_timestamp, keys)) }}
 {% endmacro %}
 
-{% macro default__check_upstream_row_count(target_exists, upstream_relation, timestamp_column, warehouse, maximum_timestamp) %}
+{% macro default__check_upstream_row_count(target_exists, upstream_relation, timestamp_column, warehouse, maximum_timestamp, keys=none) %}
 
     {# Initialise macro context #}
     {% set macro_ctx = dbt_macro_polo.create_macro_context('check_upstream_row_count') %}
@@ -78,7 +84,9 @@
     {%- set optimiser_config = var('warehouse_optimiser', {}) -%}
     {%- set global_optimisation_enabled = optimiser_config.get('enabled', false) -%}
 
-    {# Resolve upstream relation #}
+    {# Resolve upstream relation (keep the original name so the consumer can infer
+       this upstream's key type from its layer, e.g. stg_/int_/fact_ convention) #}
+    {%- set upstream_name = upstream_relation -%}
 
     {%- if '.' in upstream_relation -%}
         {%- set upstream_relation = source(upstream_relation.split('.')[0], upstream_relation.split('.')[1]) -%}
@@ -97,7 +105,7 @@
                 {% if var('selective_refresh', false) == false %}
                     where {{ timestamp_column }} > {{ maximum_timestamp }}
                 {% else %}
-                    where {{ aa_utils.selective_refresh_filter() }}
+                    where {{ dbt_macro_polo.polo_selective_refresh_filter(keys=keys, relation=upstream_name) }}
                 {% endif %}
             {% endif %}
         )


### PR DESCRIPTION
# Description

Please iunclude a synopsis of the changes and the underlying issue. Please also include important motivation and context. List any dependencies needed for this modification.

**dbt_macro_polo** does not implement selective refresh — it only exposes dispatch hooks. Consuming projects override `default__polo_is_selective_refresh` and `default__polo_selective_refresh_filter` in `search_order` to plug in their own logic (e.g. a filter macro from another package or the project). Polo has no dependency on any particular filter implementation.

**Changes:**

- Adds **`polo_is_selective_refresh()`** — “is selective refresh active for this model on this run?”. Default returns `false`, so behaviour is unchanged unless a consumer wires the hook. Used by delete+insert merge and warehouse optimiser upstream probes instead of reading `var('selective_refresh')` directly, so gated deletes/probes follow whatever rules the consumer implements (typically CLI flag plus model opt-in).
- Extends **`polo_selective_refresh_filter(keys=none, relation=none)`** — forwards optional `keys` and upstream relation name to the consumer implementation. Delete calls use defaults; upstream row-count probes can pass per-upstream `keys`.
- **`get_delete_insert_merge_sql`**: selective delete branch gated on `polo_is_selective_refresh()`.
- **`check_upstream_row_count`**: optional `keys` argument; upstream list may be plain names or `{name, keys}` mappings; probe uses `polo_selective_refresh_filter(keys=..., relation=...)` (removes any hard-coded package filter call from polo).

**Not a breaking change:** defaults preserve standard incremental behaviour (`polo_is_selective_refresh` → `false`). Selective paths only run when the consumer’s hook returns true (usually explicit `--vars` plus model configuration). No production impact for projects that do not wire the hooks.

Fixes # (github or jira issue)

## Type of change

Please mark the appropriate change:

- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (non-breaking modification that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to fail to function properly)
- [x] Maintenance (non-breaking modification that improves the code functionality or performance)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you performed to validate your changes. Please provide instructions so that we can reproduce. Please include any additional information about your test configuration.

- [x] Default hooks — `polo_is_selective_refresh()` returns `false`; incremental delete and upstream probes follow existing timestamp/max logic with no selective filter
- [x] Dispatch contract — `polo_selective_refresh_filter` signature accepts `keys` and `relation`; consumer overrides receive the same arguments polo passes at call sites

**Test Configuration**:
* DBT Version: >=1.8.6, <2.0.0 (per dbt_project.yml)
* DBT Dependencies and version: None required in polo itself; end-to-end selective refresh is validated in the consuming project after wiring dispatch overrides

Full selective refresh behaviour is owned by the consumer implementation behind the hooks, not by this package.

# Attachments:


- [ ] I'm including run logs.
- [ ] I'm attaching links to resources supporting my pull request.
- [ ] I'm including screenshots.

Please post any logs (text files, screenshots, or URLs) that support this pull request here.
These might include test cases, commands needed to reproduce the precise behaviour of the code, 
more detailed documentation, or pictures that support this pull request.

Each supplementary attachment should include a brief description of what it represents and what it covers.

# Post-deployment instructions:

1. Bump **dbt-macro-polo** in consuming projects.
2. In `dbt_project.yml` dispatch, register project macros ahead of polo:
   - `default__polo_is_selective_refresh` — return whether selective refresh is active for the current model/run
   - `default__polo_selective_refresh_filter` — return the SQL predicate (without `WHERE`) for delete/probe scoping; honour `keys` and `relation` when passed
3. Optional: warehouse optimiser upstream lists may use `{name: '<model>', keys: 'business'|'surrogate'}` when upstreams use different key types.
4. Selective refresh remains opt-in via the consumer’s vars and model meta; polo does not enable it by itself.

# Checklist:

- [ ] This code relates to an issue that has been evaluated and approved for development
- [x] My code adheres to the project's style guidelines
- [x] I conducted a self-review of my code
- [x] I've commented my code, especially in difficult-to-understand places
- [ ] I've made the necessary changes to the documentation and the README.md (if applicable)
- [ ] There are no new warnings as a result of my change
- [x] I've included tests and descriptions to show that my fix is effective or that my feature works
- [ ] Following my changes, both new and existing integration tests pass locally and CI pipeline