### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ vars:
     warehouse_optimiser: # Required for warehouse optimiser functionality
       enabled: true # Enable warehouse optimiser in your project - global setting
       default_warehouse_size: 'xs' # Default warehouse size to use if no specific settings are provided
+      default_monitoring: # Optional: project-wide fallback monitoring for any model without its own per-operation `monitoring` block
+        enabled: true
+        thresholds:
+          - rows: 250000000
+            warehouse_size: xl
+          - rows: 500000000
+            warehouse_size: 2xl
     warehouse_config: # Required for warehouse config functionality
       warehouse_size: ['xs', 's', 'm', 'l', 'xl', '2xl'] # Explicit list of available warehouse sizes in your project
       environment:

--- a/macros/warehouse_optimiser/handle_scheduling.sql
+++ b/macros/warehouse_optimiser/handle_scheduling.sql
@@ -17,7 +17,22 @@
     {# Get scheduling configuration #}
     {% set scheduling_config = operation_config.get('scheduling', {}) %}
     {% set scheduling_enabled = scheduling_config.get('enabled', false) %}
-    {% set monitoring_enabled = operation_config.get('monitoring', {}).get('enabled', false) %}
+
+    {#
+        Resolve the effective monitoring config for this operation.
+        Precedence:
+          1. The operation's own `monitoring` block (model meta) wins when present,
+             including an explicit `enabled: false` to opt a model out.
+          2. Project-wide `vars.macro_polo.warehouse_optimiser.default_monitoring` is the
+             global fallback, so a single threshold set can apply to every model without
+             repeating it per model. dbt shallow-merges `meta` (MergeBehavior.Update), so a
+             model's own `meta.warehouse_optimiser` clobbers any project-level one; this
+             fallback therefore has to live in the macro, not in dbt_project.yml meta.
+    #}
+    {% set default_monitoring = var('macro_polo', {}).get('warehouse_optimiser', {}).get('default_monitoring', {}) %}
+    {% set effective_monitoring = operation_config.get('monitoring') if operation_config.get('monitoring') is not none else default_monitoring %}
+    {% set monitoring_enabled = effective_monitoring.get('enabled', false) %}
+    {% set monitoring_thresholds = effective_monitoring.get('thresholds', []) %}
     {% set final_size = namespace(value=default_warehouse_size) %}
 
     {# Check if scheduling is enabled #}
@@ -66,7 +81,7 @@
                 {% set final_size.value = dbt_macro_polo.handle_monitoring(
                     operation_config,
                     row_count,
-                    operation_config.get('monitoring', {}).get('thresholds', []),
+                    monitoring_thresholds,
                     operation_config.get('warehouse_size', default_warehouse_size)
                 ) %}
             {% else %}
@@ -81,7 +96,7 @@
             {% set final_size.value = dbt_macro_polo.handle_monitoring(
                 operation_config,
                 row_count,
-                operation_config.get('monitoring', {}).get('thresholds', []),
+                monitoring_thresholds,
                 operation_config.get('warehouse_size', default_warehouse_size)
             ) %}
         {% else %}

--- a/macros/warehouse_optimiser/schema.md
+++ b/macros/warehouse_optimiser/schema.md
@@ -41,6 +41,13 @@ vars:
     warehouse_optimiser: # Required for warehouse optimiser functionality
       enabled: true # Enable warehouse optimiser in your project - global setting
       default_warehouse_size: 'xs' # Default warehouse size to use if no specific settings are provided
+      default_monitoring: # Optional: project-wide fallback monitoring applied to every model that has no per-operation `monitoring` block
+        enabled: true
+        thresholds:
+          - rows: 250000000
+            warehouse_size: xl # Size used when the upstream row count meets this threshold
+          - rows: 500000000
+            warehouse_size: 2xl
     warehouse_config: # Required for warehouse config functionality
       warehouse_size: ['xs', 's', 'm', 'l', 'xl', '2xl'] # Explicit list of available warehouse sizes in your project
       environment:
@@ -105,6 +112,7 @@ config:
 - **Intelligent Monitoring**:
   - Row count-based thresholds
   - Automatic warehouse scaling
+  - Project-wide default via `vars.macro_polo.warehouse_optimiser.default_monitoring`, applied to any operation (`ctas`/`delete`/`insert`) that does not define its own `monitoring` block. Precedence: per-schedule `monitoring` > per-operation `monitoring` (model meta) > project `default_monitoring`. Set a per-operation `monitoring: { enabled: false }` to opt a model out.
 
 - **Flexible Scheduling**:
   - Time-based warehouse allocation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-macro-polo"
-version = "0.1.0-beta.1"
+version = "0.1.1-beta.1"
 description = "A sophisticated exploration of dbt macro capabilities, pushing the boundaries of what's possible with dbt's macro system."
 authors = ["Dominik Golebiewski <dominik.golebiewski@atheon.co.uk>"]
 license = "MIT"


### PR DESCRIPTION
This pull request introduces a project-wide default monitoring configuration for the warehouse optimiser, allowing teams to define fallback monitoring thresholds that apply to all models unless a model specifies its own settings. This enhances maintainability by reducing repetitive configuration and clarifies the precedence of monitoring settings. Documentation has been updated to explain the new behavior, and the package version is incremented.

**Warehouse optimiser monitoring enhancements:**

* Added support for a `default_monitoring` block in `vars.macro_polo.warehouse_optimiser`, enabling project-wide fallback monitoring thresholds for any model without its own `monitoring` block. The precedence is: per-schedule `monitoring` > per-operation `monitoring` (model meta) > project `default_monitoring`. Models can opt out by setting `monitoring: { enabled: false }` in their configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R68) [[2]](diffhunk://#diff-a8ee4b7d3f4e8876d15c2528e0e436a54dd5dea98c7813ff83f0eac5c11758a5R44-R50) [[3]](diffhunk://#diff-070985ee7f4391f14f63242d880b3c9ca20d114c972e1c561b1e9c83b0c11054L20-R35)
* Updated macro logic in `macros/warehouse_optimiser/handle_scheduling.sql` to resolve and apply the effective monitoring configuration, using the new fallback when appropriate. [[1]](diffhunk://#diff-070985ee7f4391f14f63242d880b3c9ca20d114c972e1c561b1e9c83b0c11054L20-R35) [[2]](diffhunk://#diff-070985ee7f4391f14f63242d880b3c9ca20d114c972e1c561b1e9c83b0c11054L69-R84) [[3]](diffhunk://#diff-070985ee7f4391f14f63242d880b3c9ca20d114c972e1c561b1e9c83b0c11054L84-R99)

**Documentation updates:**

* Updated `README.md` and `macros/warehouse_optimiser/schema.md` to document the new `default_monitoring` option, its usage, and the configuration precedence. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R68) [[2]](diffhunk://#diff-a8ee4b7d3f4e8876d15c2528e0e436a54dd5dea98c7813ff83f0eac5c11758a5R44-R50) [[3]](diffhunk://#diff-a8ee4b7d3f4e8876d15c2528e0e436a54dd5dea98c7813ff83f0eac5c11758a5R115)

**Versioning:**

* Bumped package version to `0.1.1-beta.1` in `pyproject.toml` to reflect the new feature.